### PR TITLE
fix: the issue #3959

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -239,7 +239,7 @@ def JS_RUNTIME = {
 
     // Check if Hermes is enabled in app setup
     def appProject = rootProject.allprojects.find { it.plugins.hasPlugin('com.android.application') }
-    if ((REACT_NATIVE_MINOR_VERSION >= 71 && appProject?.hermesEnabled?.toBoolean()) || appProject?.ext?.react?.enableHermes?.toBoolean()) {
+    if ((REACT_NATIVE_MINOR_VERSION >= 71) || appProject?.ext?.react?.enableHermes?.toBoolean()) {
         return "hermes"
     }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

<!-- I am upgrading React Native from V0.70.6 to V0.71.0 and react-native-reanimated from V2.14.1 to V2.14.2 facing the error saying "Could not get unknown property 'hermesEnabled' for project ':app' of type org.gradle.api.Project.". Include "Fixes #3959" if applicable. -->
